### PR TITLE
Fix "map" attribute when serializing template properties to XML

### DIFF
--- a/src/EventTraceKit.EventTracing/EventManifestXmlExtensions.cs
+++ b/src/EventTraceKit.EventTracing/EventManifestXmlExtensions.cs
@@ -292,6 +292,8 @@ namespace EventTraceKit.EventTracing
                 elem.Add(new XAttribute("length", property.Length));
             if (property.Count.IsSpecified)
                 elem.Add(new XAttribute("count", property.Count));
+            if (property.Map != null)
+                elem.Add(new XAttribute("map", property.Map.Name));
             return elem;
         }
 


### PR DESCRIPTION
This commit adds missing `map` attribute to manifest XML serialization. For example:
```xml
<data name="PacketDirection" inType="win:UInt32" map="DirectionMap"/>
```
from `Microsoft-Windows-WFP`

The `map` attribute returned by Microsoft at least in:
```csharp
using Microsoft.Diagnostics.Tracing.Parsers;
RegisteredTraceEventParser.GetManifestForRegisteredProvider("Microsoft-Windows-WFP");
```